### PR TITLE
Wrap the indexing on startup in a transaction

### DIFF
--- a/src/db.c
+++ b/src/db.c
@@ -136,3 +136,27 @@ insert_file(file_t *file)
 
     sqlite3_finalize(stmt);
 }
+
+void
+begin_transaction() {
+    sqlite3_stmt *stmt;
+    sqlite3_prepare_v2(data->db, "BEGIN TRANSACTION;", -1, &stmt, NULL);
+     
+    if((rc = sqlite3_step(stmt)) != SQLITE_DONE) {
+        printf("Couldn't begin transaction: %s\n", sqlite3_errmsg(data->db));
+    }
+
+    sqlite3_finalize(stmt);
+}
+
+void
+commit_transaction() {
+    sqlite3_stmt *stmt;
+    sqlite3_prepare_v2(data->db, "COMMIT;", -1, &stmt, NULL);
+     
+    if((rc = sqlite3_step(stmt)) != SQLITE_DONE) {
+        printf("Couldn't commit transaction: %s\n", sqlite3_errmsg(data->db));
+    }
+
+    sqlite3_finalize(stmt);
+}

--- a/src/db.c
+++ b/src/db.c
@@ -139,24 +139,22 @@ insert_file(file_t *file)
 
 void
 begin_transaction() {
-    sqlite3_stmt *stmt;
-    sqlite3_prepare_v2(data->db, "BEGIN TRANSACTION;", -1, &stmt, NULL);
-     
-    if((rc = sqlite3_step(stmt)) != SQLITE_DONE) {
-        printf("Couldn't begin transaction: %s\n", sqlite3_errmsg(data->db));
-    }
+    char* errmsg;
+    sqlite3_exec(data->db, "BEGIN TRANSACTION;", NULL, NULL, &errmsg);
 
-    sqlite3_finalize(stmt);
+    if(errmsg != NULL) { 
+        printf("Couldn't begin transaction: %s\n", errmsg);
+        sqlite3_free(errmsg);
+    }
 }
 
 void
 commit_transaction() {
-    sqlite3_stmt *stmt;
-    sqlite3_prepare_v2(data->db, "COMMIT;", -1, &stmt, NULL);
-     
-    if((rc = sqlite3_step(stmt)) != SQLITE_DONE) {
-        printf("Couldn't commit transaction: %s\n", sqlite3_errmsg(data->db));
-    }
+    char* errmsg;
+    sqlite3_exec(data->db, "COMMIT;", NULL, NULL, &errmsg);
 
-    sqlite3_finalize(stmt);
+    if(errmsg != NULL) { 
+        printf("Couldn't commit transaction: %s\n", errmsg);
+        sqlite3_free(errmsg);
+    }
 }

--- a/src/db.h
+++ b/src/db.h
@@ -28,4 +28,10 @@ resolve_title(char *artist, char *album, char *title);
 char *
 rename_file(tags_t *old, tags_t *new);
 
+void
+begin_transaction();
+
+void
+commit_transaction();
+
 #endif //MUFS_DB_H

--- a/src/indexing.c
+++ b/src/indexing.c
@@ -60,6 +60,8 @@ void
 index_files(const char *path)
 {
     int ret = 0;
+    begin_transaction();
     if((ret = nftw(path, &store_file, FD_NUM, 0)) != 0)
         exit(ret);
+    commit_transaction();
 }


### PR DESCRIPTION
This speeds up startup time by a factor of approximately 127x on my system.
https://www.sqlite.org/faq.html#q19
